### PR TITLE
Refactor: Modernize credit history management and optimize payment va…

### DIFF
--- a/payment-service/payment-container/src/main/resources/db/migration/V2__add_unique_constraint_to_credit_entry.sql
+++ b/payment-service/payment-container/src/main/resources/db/migration/V2__add_unique_constraint_to_credit_entry.sql
@@ -1,0 +1,5 @@
+-- Eğer kullanıcının cüzdanı yoksa ve aynı anda birden fazla para yüklenmesi yapılmaya kalkılırsa
+-- credit entry içinde aynı kişiye ait birden fazla kayıt açılacaktır. Bunun olmasını engellemek için unique constraint ekleniyor.
+-- Aksi halde bir kişinin birden fazla cüzdanı olması durumu yaşanacaktır.
+ALTER TABLE "payment".credit_entry
+    ADD CONSTRAINT uq_credit_entry_customer_id UNIQUE (customer_id);

--- a/payment-service/payment-dataaccess/src/main/java/com/berkay/payment/service/dataaccess/credithistory/adapter/CreditHistoryRepositoryImpl.java
+++ b/payment-service/payment-dataaccess/src/main/java/com/berkay/payment/service/dataaccess/credithistory/adapter/CreditHistoryRepositoryImpl.java
@@ -9,7 +9,6 @@ import com.berkay.payment.service.domain.ports.output.repository.CreditHistoryRe
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Component
@@ -31,13 +30,12 @@ public class CreditHistoryRepositoryImpl implements CreditHistoryRepository {
     }
 
     @Override
-    public Optional<List<CreditHistory>> findByCustomerId(CustomerId customerId) {
-        Optional<List<CreditHistoryEntity>> creditHistory =
+    public List<CreditHistory> findByCustomerId(CustomerId customerId) {
+        List<CreditHistoryEntity> creditHistoryList =
                 creditHistoryJpaRepository.findByCustomerId(customerId.getValue());
-        return creditHistory
-                .map(creditHistoryList ->
-                        creditHistoryList.stream()
-                                .map(creditHistoryDataAccessMapper::creditHistoryEntityToCreditHistory)
-                                .collect(Collectors.toList()));
+
+        return creditHistoryList.stream()
+                .map(creditHistoryDataAccessMapper::creditHistoryEntityToCreditHistory)
+                .collect(Collectors.toList());
     }
 }

--- a/payment-service/payment-dataaccess/src/main/java/com/berkay/payment/service/dataaccess/credithistory/repository/CreditHistoryJpaRepository.java
+++ b/payment-service/payment-dataaccess/src/main/java/com/berkay/payment/service/dataaccess/credithistory/repository/CreditHistoryJpaRepository.java
@@ -5,13 +5,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface CreditHistoryJpaRepository extends JpaRepository<CreditHistoryEntity, UUID> {
 
-    Optional<List<CreditHistoryEntity>> findByCustomerId(UUID customerId);
+    List<CreditHistoryEntity> findByCustomerId(UUID customerId);
 
 
 }

--- a/payment-service/payment-domain/payment-application-service/src/main/java/com/berkay/payment/service/domain/PaymentRequestHelper.java
+++ b/payment-service/payment-domain/payment-application-service/src/main/java/com/berkay/payment/service/domain/PaymentRequestHelper.java
@@ -5,8 +5,9 @@ import com.berkay.domain.valueobject.PaymentStatus;
 import com.berkay.outbox.OutboxStatus;
 import com.berkay.payment.service.domain.dto.PaymentRequest;
 import com.berkay.payment.service.domain.entity.CreditEntry;
-import com.berkay.payment.service.domain.entity.CreditHistory;
 import com.berkay.payment.service.domain.entity.Payment;
+import com.berkay.payment.service.domain.event.PaymentCancelledEvent;
+import com.berkay.payment.service.domain.event.PaymentCompletedEvent;
 import com.berkay.payment.service.domain.event.PaymentEvent;
 import com.berkay.payment.service.domain.exception.PaymentApplicationServiceException;
 import com.berkay.payment.service.domain.exception.PaymentNotFoundException;
@@ -65,11 +66,12 @@ public class PaymentRequestHelper {
         log.info("Received payment complete event for order id: {}", paymentRequest.getOrderId());
         Payment payment = paymentDataMapper.paymentRequestModelToPayment(paymentRequest);
         CreditEntry creditEntry = getCreditEntry(payment.getCustomerId());
-        List<CreditHistory> creditHistories = getCreditHistory(payment.getCustomerId());
+
         List<String> failureMessages = new ArrayList<>();
         PaymentEvent paymentEvent =
-                paymentDomainService.validateAndInitiatePayment(payment, creditEntry, creditHistories, failureMessages);
-        persistDbObjects(payment, creditEntry, creditHistories, failureMessages);
+                paymentDomainService.validateAndInitiatePayment(payment, creditEntry, failureMessages);
+
+        persistDbObjects(payment, creditEntry, paymentEvent, failureMessages);
 
         orderOutboxHelper.saveOrderOutboxMessage(paymentDataMapper.paymentEventToOrderEventPayload(paymentEvent),
                 paymentEvent.getPayment().getPaymentStatus(),
@@ -95,11 +97,11 @@ public class PaymentRequestHelper {
         }
         Payment payment = paymentResponse.get();
         CreditEntry creditEntry = getCreditEntry(payment.getCustomerId());
-        List<CreditHistory> creditHistories = getCreditHistory(payment.getCustomerId());
+
         List<String> failureMessages = new ArrayList<>();
         PaymentEvent paymentEvent = paymentDomainService
-                .validateAndCancelPayment(payment, creditEntry, creditHistories, failureMessages);
-        persistDbObjects(payment, creditEntry, creditHistories, failureMessages);
+                .validateAndCancelPayment(payment, creditEntry, failureMessages);
+        persistDbObjects(payment, creditEntry, paymentEvent, failureMessages);
 
         orderOutboxHelper.saveOrderOutboxMessage(paymentDataMapper.paymentEventToOrderEventPayload(paymentEvent),
                 paymentEvent.getPayment().getPaymentStatus(),
@@ -117,28 +119,25 @@ public class PaymentRequestHelper {
         return creditEntry.get();
     }
 
-    // TODO: Bir kullanıcı oluşturulduğunda o zaman history ve entry'nin boş olmaması lazım 0 birimlik bir transaction gerek
-    private List<CreditHistory> getCreditHistory(CustomerId customerId) {
-        Optional<List<CreditHistory>> creditHistories = creditHistoryRepository.findByCustomerId(customerId);
-        if (creditHistories.isEmpty()) {
-            log.error("Could not find credit history for customer: {}", customerId.getValue());
-            throw new PaymentApplicationServiceException("Could not find credit history for customer: " +
-                    customerId.getValue());
-        }
-        return creditHistories.get();
-    }
-
     private void persistDbObjects(Payment payment,
                                   CreditEntry creditEntry,
-                                  List<CreditHistory> creditHistories,
+                                  PaymentEvent paymentEvent,
                                   List<String> failureMessages) {
         paymentRepository.save(payment);
+
         // Yalnızca herhangi bir hata bulunmadığında kullanıcının cüzdan hareketleri güncellenir!
         // Aksi durumda sadece bilgilendirme amaçlı olarak ödeme bilgisi tabloya yazılır ve bitirilir.
         if (failureMessages.isEmpty()) {
+            // Cüzdanın yeni bakiyesini kaydet
             creditEntryRepository.save(creditEntry);
-            // İlgili sipariş için oluşturulan history kaydedilir
-            creditHistoryRepository.save(creditHistories.get(creditHistories.size() - 1));
+
+            // History Kaydı: Event tipine göre içinden çekiyoruz
+            if (paymentEvent instanceof PaymentCompletedEvent completedEvent) {
+                creditHistoryRepository.save(completedEvent.getCreditHistory());
+            }
+            else if (paymentEvent instanceof PaymentCancelledEvent cancelledEvent) {
+                creditHistoryRepository.save(cancelledEvent.getCreditHistory());
+            }
         }
     }
 

--- a/payment-service/payment-domain/payment-application-service/src/main/java/com/berkay/payment/service/domain/ports/output/repository/CreditHistoryRepository.java
+++ b/payment-service/payment-domain/payment-application-service/src/main/java/com/berkay/payment/service/domain/ports/output/repository/CreditHistoryRepository.java
@@ -4,11 +4,10 @@ import com.berkay.domain.valueobject.CustomerId;
 import com.berkay.payment.service.domain.entity.CreditHistory;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface CreditHistoryRepository {
 
     CreditHistory save(CreditHistory creditHistory);
 
-    Optional<List<CreditHistory>> findByCustomerId(CustomerId customerId);
+    List<CreditHistory> findByCustomerId(CustomerId customerId);
 }

--- a/payment-service/payment-domain/payment-domain-core/src/main/java/com/berkay/payment/service/domain/PaymentDomainService.java
+++ b/payment-service/payment-domain/payment-domain-core/src/main/java/com/berkay/payment/service/domain/PaymentDomainService.java
@@ -11,12 +11,10 @@ public interface PaymentDomainService {
 
     PaymentEvent validateAndInitiatePayment(Payment payment,
                                             CreditEntry creditEntry,
-                                            List<CreditHistory> creditHistories,
                                             List<String> failureMessages);
 
     PaymentEvent validateAndCancelPayment(Payment payment,
                                           CreditEntry creditEntry,
-                                          List<CreditHistory> creditHistories,
                                           List<String> failureMessages);
 
     void validateAndUpdateCreditEntry(CreditEntry creditEntry,

--- a/payment-service/payment-domain/payment-domain-core/src/main/java/com/berkay/payment/service/domain/PaymentDomainServiceImpl.java
+++ b/payment-service/payment-domain/payment-domain-core/src/main/java/com/berkay/payment/service/domain/PaymentDomainServiceImpl.java
@@ -1,6 +1,5 @@
 package com.berkay.payment.service.domain;
 
-import com.berkay.domain.valueobject.Money;
 import com.berkay.domain.valueobject.PaymentStatus;
 import com.berkay.payment.service.domain.entity.CreditEntry;
 import com.berkay.payment.service.domain.entity.CreditHistory;
@@ -62,19 +61,18 @@ public class PaymentDomainServiceImpl implements PaymentDomainService {
     @Override
     public PaymentEvent validateAndInitiatePayment(Payment payment,
                                                    CreditEntry creditEntry,
-                                                   List<CreditHistory> creditHistories,
                                                    List<String> failureMessages) {
         payment.validatePayment(failureMessages);
         payment.initializePayment();
         validateCreditEntry(payment, creditEntry, failureMessages);
         subtractCreditEntry(payment, creditEntry);
-        updateCreditHistory(payment, creditHistories, TransactionType.DEBIT);
-        validateCreditHistory(creditEntry, creditHistories, failureMessages);
 
         if (failureMessages.isEmpty()) {
+            CreditHistory history = createCreditHistory(payment, TransactionType.DEBIT);
+
             log.info("Payment is initiated for order id: {}", payment.getOrderId().getValue());
             payment.updateStatus(PaymentStatus.COMPLETED);
-            return new PaymentCompletedEvent(payment, ZonedDateTime.now(ZoneId.of(UTC)));
+            return new PaymentCompletedEvent(payment, ZonedDateTime.now(ZoneId.of(UTC)), history);
         } else {
             log.info("Payment initiation is failed for order id: {}", payment.getOrderId().getValue());
             payment.updateStatus(PaymentStatus.FAILED);
@@ -85,16 +83,16 @@ public class PaymentDomainServiceImpl implements PaymentDomainService {
     @Override
     public PaymentEvent validateAndCancelPayment(Payment payment,
                                                  CreditEntry creditEntry,
-                                                 List<CreditHistory> creditHistories,
                                                  List<String> failureMessages) {
-        payment.validatePayment(failureMessages);
+        payment.validatePaymentForCancellation(failureMessages);
         addCreditEntry(payment, creditEntry);
-        updateCreditHistory(payment, creditHistories, TransactionType.CREDIT);
 
         if (failureMessages.isEmpty()) {
+            CreditHistory creditHistory = createCreditHistory(payment, TransactionType.CREDIT);
+
             log.info("Payment is cancelled for order id: {}", payment.getOrderId().getValue());
             payment.updateStatus(PaymentStatus.CANCELLED);
-            return new PaymentCancelledEvent(payment, ZonedDateTime.now(ZoneId.of(UTC)));
+            return new PaymentCancelledEvent(payment, ZonedDateTime.now(ZoneId.of(UTC)), creditHistory);
         } else {
             log.info("Payment cancellation is failed for order id: {}", payment.getOrderId().getValue());
             payment.updateStatus(PaymentStatus.FAILED);
@@ -115,44 +113,14 @@ public class PaymentDomainServiceImpl implements PaymentDomainService {
         creditEntry.subtractCreditAmount(payment.getPrice());
     }
 
-    private void updateCreditHistory(Payment payment,
-                                     List<CreditHistory> creditHistories,
+    private CreditHistory createCreditHistory(Payment payment,
                                      TransactionType transactionType) {
-        creditHistories.add(CreditHistory.builder()
+        return CreditHistory.builder()
                 .creditHistoryId(new CreditHistoryId(UUID.randomUUID()))
                 .customerId(payment.getCustomerId())
                 .amount(payment.getPrice())
                 .transactionType(transactionType)
-                .build());
-    }
-
-
-    private void validateCreditHistory(CreditEntry creditEntry,
-                                       List<CreditHistory> creditHistories,
-                                       List<String> failureMessages) {
-        Money totalCreditHistory = getTotalHistoryAmount(creditHistories, TransactionType.CREDIT);
-        Money totalDebitHistory = getTotalHistoryAmount(creditHistories, TransactionType.DEBIT);
-
-        if (totalDebitHistory.isGreaterThan(totalCreditHistory)) {
-            log.error("Customer with id: {} doesn't have enough credit according to credit history",
-                    creditEntry.getCustomerId().getValue());
-            failureMessages.add("Customer with id=" + creditEntry.getCustomerId().getValue() +
-                    " doesn't have enough credit according to credit history!");
-        }
-
-        if (!creditEntry.getTotalCreditAmount().equals(totalCreditHistory.subtract(totalDebitHistory))) {
-            log.error("Credit history total is not equal to current credit for customer id: {}!",
-                    creditEntry.getCustomerId().getValue());
-            failureMessages.add("Credit history total is not equal to current credit for customer id: " +
-                    creditEntry.getCustomerId().getValue() + "!");
-        }
-    }
-
-    private Money getTotalHistoryAmount(List<CreditHistory> creditHistories, TransactionType transactionType) {
-        return creditHistories.stream()
-                .filter(creditHistory -> transactionType == creditHistory.getTransactionType())
-                .map(CreditHistory::getAmount)
-                .reduce(Money.ZERO, Money::add);
+                .build();
     }
 
     private void addCreditEntry(Payment payment, CreditEntry creditEntry) {

--- a/payment-service/payment-domain/payment-domain-core/src/main/java/com/berkay/payment/service/domain/entity/Payment.java
+++ b/payment-service/payment-domain/payment-domain-core/src/main/java/com/berkay/payment/service/domain/entity/Payment.java
@@ -32,6 +32,14 @@ public class Payment extends AggregateRoot<PaymentId> {
         }
     }
 
+    public void validatePaymentForCancellation(List<String> failureMessages) {
+        validatePayment(failureMessages);
+        // Sadece COMPLETED statüsündeki bir ödeme iptal edilebilir.
+        if (paymentStatus != PaymentStatus.COMPLETED) {
+            failureMessages.add("Payment is not in COMPLETED status, current status: " + paymentStatus);
+        }
+    }
+
     public void updateStatus(PaymentStatus paymentStatus) {
         this.paymentStatus = paymentStatus;
     }

--- a/payment-service/payment-domain/payment-domain-core/src/main/java/com/berkay/payment/service/domain/event/PaymentCancelledEvent.java
+++ b/payment-service/payment-domain/payment-domain-core/src/main/java/com/berkay/payment/service/domain/event/PaymentCancelledEvent.java
@@ -1,5 +1,6 @@
 package com.berkay.payment.service.domain.event;
 
+import com.berkay.payment.service.domain.entity.CreditHistory;
 import com.berkay.payment.service.domain.entity.Payment;
 
 import java.time.ZonedDateTime;
@@ -7,8 +8,16 @@ import java.util.Collections;
 
 public class PaymentCancelledEvent extends PaymentEvent {
 
+    private final CreditHistory creditHistory;
+
     public PaymentCancelledEvent(Payment payment,
-                                 ZonedDateTime createdAt) {
+                                 ZonedDateTime createdAt,
+                                 CreditHistory creditHistory) {
         super(payment, createdAt, Collections.emptyList());
+        this.creditHistory = creditHistory;
+    }
+
+    public CreditHistory getCreditHistory() {
+        return creditHistory;
     }
 }

--- a/payment-service/payment-domain/payment-domain-core/src/main/java/com/berkay/payment/service/domain/event/PaymentCompletedEvent.java
+++ b/payment-service/payment-domain/payment-domain-core/src/main/java/com/berkay/payment/service/domain/event/PaymentCompletedEvent.java
@@ -1,5 +1,6 @@
 package com.berkay.payment.service.domain.event;
 
+import com.berkay.payment.service.domain.entity.CreditHistory;
 import com.berkay.payment.service.domain.entity.Payment;
 
 import java.time.ZonedDateTime;
@@ -7,8 +8,16 @@ import java.util.Collections;
 
 public class PaymentCompletedEvent extends PaymentEvent {
 
+    private final CreditHistory creditHistory;
+
     public PaymentCompletedEvent(Payment payment,
-                                 ZonedDateTime createdAt) {
+                                 ZonedDateTime createdAt,
+                                 CreditHistory creditHistory) {
         super(payment, createdAt, Collections.emptyList());
+        this.creditHistory = creditHistory;
+    }
+
+    public CreditHistory getCreditHistory() {
+        return creditHistory;
     }
 }


### PR DESCRIPTION
PR Description
This PR refactors the legacy credit history management and reconciliation logic to improve performance and maintainability. Key changes include:

PaymentRequestHelper.java: Removed the getCreditHistory method and the legacy TODO that threw exceptions for new users. Discontinued fetching the entire credit history list in persistPayment and persistCancelPayment. Updated persistDbObjects to receive PaymentEvent to handle single history record persistence via events.

PaymentDomainService.java (Interface): Cleaned up validateAndInitiatePayment and validateAndCancelPayment signatures by removing the List<CreditHistory> parameter.

PaymentDomainServiceImpl.java: Eliminated validateCreditHistory and getTotalHistoryAmount (reconciliation logic). Replaced the list-based updateCreditHistory with a private createCreditHistory method that returns a single object. Integrated the new history record into the Event constructor for upstream processing.

PaymentCompletedEvent.java & PaymentCancelledEvent.java: Added a private final CreditHistory creditHistory field to both classes. Updated constructors and added necessary getters to support the new flow.

CreditHistoryJpaRepository / Repository / Impl: Updated findByCustomerId return type from Optional<List<CreditHistory>> to a standard List<CreditHistory> to better handle empty results.

Payment.java: Introduced validatePaymentForCancellation method leveraging method composition. Added a critical state-machine check to ensure only COMPLETED payments can be cancelled, alongside the standard price validation.

V2__add_unique_constraint_to_credit_entry.sql: Added a Unique Constraint on customerId in the CreditEntry table to prevent duplicate wallets and enhance data integrity at the database level.

Note: Following this refactor, a separate PR will be submitted to implement Pessimistic Locking to ensure atomic balance updates and prevent race conditions.