### PR TITLE
(payment): implement database-backed idempotency for wallet transactions

### DIFF
--- a/TakeMyOrder.postman_collection.json
+++ b/TakeMyOrder.postman_collection.json
@@ -2189,6 +2189,11 @@
                             {
                                 "key": "Content-Type",
                                 "value": "application/json"
+                            },
+                            {
+                                "key": "Idempotency-Key",
+                                "value": "{{$guid}}",
+                                "type": "text"
                             }
                         ],
                         "body": {
@@ -2218,6 +2223,11 @@
                             {
                                 "key": "Content-Type",
                                 "value": "application/json"
+                            },
+                            {
+                                "key": "Idempotency-Key",
+                                "value": "{{$guid}}",
+                                "type": "text"
                             }
                         ],
                         "body": {

--- a/payment-service/payment-application/src/main/java/com/berkay/payment/service/application/rest/WalletController.java
+++ b/payment-service/payment-application/src/main/java/com/berkay/payment/service/application/rest/WalletController.java
@@ -26,9 +26,11 @@ public class WalletController {
     @PostMapping("/{ownerId}/deposit")
     @PreAuthorize("@paymentAuthService.hasPermission(authentication, 'can_manage_payment', #ownerId)")
     public ResponseEntity<WalletBalanceResponse> deposit(@PathVariable("ownerId") UUID ownerId,
+                                        @RequestHeader("Idempotency-Key") String idempotencyKey,
                                         @RequestBody WalletDepositCommand command) {
         log.info("Received deposit request for owner id: {}", ownerId);
         command.setOwnerId(ownerId);
+        command.setIdempotencyKey(idempotencyKey);
         WalletBalanceResponse response = walletApplicationService.deposit(command);
         return ResponseEntity.ok(response);
     }
@@ -36,9 +38,11 @@ public class WalletController {
     @PostMapping("/{ownerId}/withdraw")
     @PreAuthorize("@paymentAuthService.hasPermission(authentication, 'can_manage_payment', #ownerId)")
     public ResponseEntity<WalletBalanceResponse> withdraw(@PathVariable("ownerId") UUID ownerId,
+                                         @RequestHeader("Idempotency-Key") String idempotencyKey,
                                          @RequestBody WalletWithdrawCommand command) {
         log.info("Received withdraw request for owner id: {}", ownerId);
         command.setOwnerId(ownerId);
+        command.setIdempotencyKey(idempotencyKey);
         WalletBalanceResponse response = walletApplicationService.withdraw(command);
         return ResponseEntity.ok(response);
     }

--- a/payment-service/payment-application/src/main/java/com/berkay/payment/service/domain/exception/handler/PaymentGlobalExceptionHandler.java
+++ b/payment-service/payment-application/src/main/java/com/berkay/payment/service/domain/exception/handler/PaymentGlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.dao.DataIntegrityViolationException;
 
 @Slf4j
 @ControllerAdvice
@@ -46,6 +47,17 @@ public class PaymentGlobalExceptionHandler extends GlobalExceptionHandler {
         return ErrorDTO.builder()
                 .code(HttpStatus.BAD_REQUEST.getReasonPhrase())
                 .message(paymentApplicationServiceException.getMessage())
+                .build();
+    }
+
+    @ResponseBody
+    @ExceptionHandler(value = {DataIntegrityViolationException.class})
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public ErrorDTO handleException(DataIntegrityViolationException dataIntegrityViolationException) {
+        log.warn("Data integrity violation occurred, possibly a duplicate idempotency key: {}", dataIntegrityViolationException.getMessage());
+        return ErrorDTO.builder()
+                .code(HttpStatus.CONFLICT.getReasonPhrase())
+                .message("This request has already been processed or violates data integrity.")
                 .build();
     }
 }

--- a/payment-service/payment-container/src/main/resources/db/migration/V7__add_idempotency_key.sql
+++ b/payment-service/payment-container/src/main/resources/db/migration/V7__add_idempotency_key.sql
@@ -1,0 +1,5 @@
+ALTER TABLE payment.wallet_transactions
+ADD COLUMN idempotency_key character varying(255);
+
+ALTER TABLE payment.wallet_transactions
+ADD CONSTRAINT wallet_transactions_idempotency_key_key UNIQUE (idempotency_key);

--- a/payment-service/payment-dataaccess/src/main/java/com/berkay/payment/service/dataaccess/wallet/entity/WalletTransactionEntity.java
+++ b/payment-service/payment-dataaccess/src/main/java/com/berkay/payment/service/dataaccess/wallet/entity/WalletTransactionEntity.java
@@ -34,6 +34,9 @@ public class WalletTransactionEntity {
     @Column(name = "reference_id")
     private String referenceId;
 
+    @Column(name = "idempotency_key", unique = true)
+    private String idempotencyKey;
+
     @Column(name = "created_at", nullable = false)
     private ZonedDateTime createdAt;
 }

--- a/payment-service/payment-dataaccess/src/main/java/com/berkay/payment/service/dataaccess/wallet/mapper/WalletDataAccessMapper.java
+++ b/payment-service/payment-dataaccess/src/main/java/com/berkay/payment/service/dataaccess/wallet/mapper/WalletDataAccessMapper.java
@@ -48,6 +48,7 @@ public class WalletDataAccessMapper {
                 .amount(walletTransaction.getAmount().getAmount())
                 .transactionType(walletTransaction.getTransactionType())
                 .referenceId(walletTransaction.getReferenceId())
+                .idempotencyKey(walletTransaction.getIdempotencyKey())
                 .createdAt(walletTransaction.getCreatedAt())
                 .build();
     }
@@ -59,6 +60,7 @@ public class WalletDataAccessMapper {
                 .amount(new Money(walletTransactionEntity.getAmount()))
                 .transactionType(walletTransactionEntity.getTransactionType())
                 .referenceId(walletTransactionEntity.getReferenceId())
+                .idempotencyKey(walletTransactionEntity.getIdempotencyKey())
                 .createdAt(walletTransactionEntity.getCreatedAt())
                 .build();
     }

--- a/payment-service/payment-domain/payment-application-service/src/main/java/com/berkay/payment/service/domain/WalletApplicationServiceImpl.java
+++ b/payment-service/payment-domain/payment-application-service/src/main/java/com/berkay/payment/service/domain/WalletApplicationServiceImpl.java
@@ -51,6 +51,7 @@ public class WalletApplicationServiceImpl implements WalletApplicationService {
                 .walletId(wallet.getId())
                 .amount(new Money(command.getAmount()))
                 .transactionType(WalletTransactionType.DEPOSIT)
+                .idempotencyKey(command.getIdempotencyKey())
                 .createdAt(ZonedDateTime.now(ZoneId.of(UTC)))
                 .build();
         walletTransactionRepository.save(transaction);
@@ -72,6 +73,7 @@ public class WalletApplicationServiceImpl implements WalletApplicationService {
                 .walletId(wallet.getId())
                 .amount(new Money(command.getAmount()))
                 .transactionType(WalletTransactionType.WITHDRAWAL)
+                .idempotencyKey(command.getIdempotencyKey())
                 .createdAt(ZonedDateTime.now(ZoneId.of(UTC)))
                 .build();
         walletTransactionRepository.save(transaction);

--- a/payment-service/payment-domain/payment-application-service/src/main/java/com/berkay/payment/service/domain/dto/wallet/WalletDepositCommand.java
+++ b/payment-service/payment-domain/payment-application-service/src/main/java/com/berkay/payment/service/domain/dto/wallet/WalletDepositCommand.java
@@ -22,4 +22,5 @@ public class WalletDepositCommand {
     @NotNull
     @Positive
     private BigDecimal amount;
+    private String idempotencyKey;
 }

--- a/payment-service/payment-domain/payment-application-service/src/main/java/com/berkay/payment/service/domain/dto/wallet/WalletWithdrawCommand.java
+++ b/payment-service/payment-domain/payment-application-service/src/main/java/com/berkay/payment/service/domain/dto/wallet/WalletWithdrawCommand.java
@@ -22,4 +22,5 @@ public class WalletWithdrawCommand {
     @NotNull
     @Positive
     private BigDecimal amount;
+    private String idempotencyKey;
 }

--- a/payment-service/payment-domain/payment-application-service/src/test/java/com/berkay/payment/service/domain/WalletApplicationServiceImplTest.java
+++ b/payment-service/payment-domain/payment-application-service/src/test/java/com/berkay/payment/service/domain/WalletApplicationServiceImplTest.java
@@ -22,7 +22,9 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import org.springframework.dao.DataIntegrityViolationException;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -94,5 +96,24 @@ class WalletApplicationServiceImplTest {
         verify(walletRepository, times(1)).findByOwnerIdWithLock(ownerId);
         verify(walletRepository, times(1)).save(wallet);
         verify(walletTransactionRepository, times(1)).save(any(WalletTransaction.class));
+    }
+
+    @Test
+    void testDeposit_WithDuplicateIdempotencyKey_ShouldThrowException() {
+        // Given
+        WalletDepositCommand command = WalletDepositCommand.builder()
+                .ownerId(ownerId)
+                .amount(new BigDecimal("50.00"))
+                .idempotencyKey("duplicate-key-123")
+                .build();
+
+        when(walletRepository.findByOwnerIdWithLock(ownerId)).thenReturn(Optional.of(wallet));
+        when(walletTransactionRepository.save(any(WalletTransaction.class)))
+                .thenThrow(new DataIntegrityViolationException("Unique index or primary key violation"));
+
+        // When & Then
+        assertThrows(DataIntegrityViolationException.class, () -> {
+            walletApplicationService.deposit(command);
+        });
     }
 }

--- a/payment-service/payment-domain/payment-domain-core/src/main/java/com/berkay/payment/service/domain/entity/WalletTransaction.java
+++ b/payment-service/payment-domain/payment-domain-core/src/main/java/com/berkay/payment/service/domain/entity/WalletTransaction.java
@@ -16,6 +16,7 @@ public class WalletTransaction extends BaseEntity<WalletTransactionId> {
     private final Money amount;
     private final WalletTransactionType transactionType;
     private final String referenceId;
+    private final String idempotencyKey;
     private final ZonedDateTime createdAt;
 
     private WalletTransaction(Builder builder) {
@@ -24,6 +25,7 @@ public class WalletTransaction extends BaseEntity<WalletTransactionId> {
         amount = builder.amount;
         transactionType = builder.transactionType;
         referenceId = builder.referenceId;
+        idempotencyKey = builder.idempotencyKey;
         createdAt = builder.createdAt;
     }
 
@@ -47,6 +49,10 @@ public class WalletTransaction extends BaseEntity<WalletTransactionId> {
         return referenceId;
     }
 
+    public String getIdempotencyKey() {
+        return idempotencyKey;
+    }
+
     public ZonedDateTime getCreatedAt() {
         return createdAt;
     }
@@ -57,6 +63,7 @@ public class WalletTransaction extends BaseEntity<WalletTransactionId> {
         private Money amount;
         private WalletTransactionType transactionType;
         private String referenceId;
+        private String idempotencyKey;
         private ZonedDateTime createdAt;
 
         private Builder() {
@@ -84,6 +91,11 @@ public class WalletTransaction extends BaseEntity<WalletTransactionId> {
 
         public Builder referenceId(String val) {
             referenceId = val;
+            return this;
+        }
+
+        public Builder idempotencyKey(String val) {
+            idempotencyKey = val;
             return this;
         }
 


### PR DESCRIPTION
- Added `V7__add_idempotency_key.sql` migration to enforce UNIQUE constraint on `idempotency_key` in `wallet_transactions` table.
- Updated `WalletTransaction` domain entity, JPA entity, and mappers to support `idempotencyKey`.
- Required `Idempotency-Key` HTTP header in WalletController for `deposit` and `withdraw` endpoints.
- Handled `DataIntegrityViolationException` in `PaymentGlobalExceptionHandler` to return HTTP 409 Conflict.
- Added unit tests to verify the idempotency behavior in `WalletApplicationServiceImplTest`.
- Updated Postman collection to inject `{{$guid}}` automatically for the Idempotency-Key header.