### PR TITLE
(identity): add CAN_REMOVE_PERSONNEL permission

### DIFF
--- a/identity-service/identity-dataaccess/src/main/resources/db/migration/V16__add_can_remove_personnel_permission.sql
+++ b/identity-service/identity-dataaccess/src/main/resources/db/migration/V16__add_can_remove_personnel_permission.sql
@@ -1,0 +1,4 @@
+-- V15__add_can_remove_personnel_permission.sql
+INSERT INTO permissions (id, code, description, domain, active, is_restricted) 
+VALUES (gen_random_uuid(), 'can_remove_personnel', 'Permission to remove personnel from a restaurant', 'RESTAURANT', true, false)
+ON CONFLICT (code) DO NOTHING;

--- a/identity-service/identity-domain/identity-domain-core/src/main/java/com/berkay/identity/service/domain/constants/PermissionConstants.java
+++ b/identity-service/identity-domain/identity-domain-core/src/main/java/com/berkay/identity/service/domain/constants/PermissionConstants.java
@@ -33,6 +33,7 @@ public final class PermissionConstants {
     public static final String CAN_UPDATE_PRODUCT = "can_update_product";
     public static final String CAN_DELETE_PRODUCT = "can_delete_product";
     public static final String CAN_ADD_PERSONNEL = "can_add_personnel";
+    public static final String CAN_REMOVE_PERSONNEL = "can_remove_personnel";
 
     // Payment Permissions
     public static final String CAN_REFUND_PAYMENT = "can_refund_payment";

--- a/identity-service/identity-domain/identity-domain-core/src/main/java/com/berkay/identity/service/domain/constants/RoleConstants.java
+++ b/identity-service/identity-domain/identity-domain-core/src/main/java/com/berkay/identity/service/domain/constants/RoleConstants.java
@@ -52,6 +52,7 @@ public class RoleConstants {
                     PermissionConstants.CAN_VIEW_RESTAURANT_ORDERS,
                     PermissionConstants.CAN_UPDATE_ORDER_STATUS,
                     PermissionConstants.CAN_ADD_PERSONNEL,
+                    PermissionConstants.CAN_REMOVE_PERSONNEL,
                     PermissionConstants.CAN_VIEW_MERCHANT_USERS,
                     PermissionConstants.CAN_VIEW_USERS,
                     PermissionConstants.CAN_VIEW_ROLES,


### PR DESCRIPTION
Introduced CAN_REMOVE_PERSONNEL constant, assigned it to RESTAURANT_OWNER role, and created Flyway V16 migration script.