### PR TITLE
test(restaurant): fix DataJpaTest configuration and add unit tests for restaurant queries

### DIFF
--- a/restaurant-service/restaurant-application/src/test/java/com/berkay/restaurant/service/domain/rest/PublicRestaurantControllerTest.java
+++ b/restaurant-service/restaurant-application/src/test/java/com/berkay/restaurant/service/domain/rest/PublicRestaurantControllerTest.java
@@ -1,0 +1,70 @@
+package com.berkay.restaurant.service.domain.rest;
+
+import com.berkay.restaurant.service.domain.dto.read.GetPublicRestaurantListQuery;
+import com.berkay.restaurant.service.domain.dto.read.GetPublicRestaurantListQueryResponse;
+import com.berkay.restaurant.service.domain.dto.read.GetPublicRestaurantQueryResponse;
+import com.berkay.restaurant.service.domain.ports.input.service.RestaurantApplicationService;
+import com.berkay.restaurant.service.domain.valueobject.CuisineType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Collections;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class PublicRestaurantControllerTest {
+
+    @Mock
+    private RestaurantApplicationService restaurantApplicationService;
+
+    @InjectMocks
+    private PublicRestaurantController publicRestaurantController;
+
+    @Test
+    void shouldReturnPublicRestaurantsSuccessfully() {
+        // Arrange
+        GetPublicRestaurantListQueryResponse expectedResponse = new GetPublicRestaurantListQueryResponse(
+                Collections.emptyList(), 0, 20, 0, 0, true);
+
+        when(restaurantApplicationService.getPublicRestaurants(any(GetPublicRestaurantListQuery.class)))
+                .thenReturn(expectedResponse);
+
+        // Act
+        ResponseEntity<GetPublicRestaurantListQueryResponse> responseEntity = 
+                publicRestaurantController.getPublicRestaurants("test", CuisineType.TURKISH, true, 0, 20);
+
+        // Assert
+        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+        assertEquals(expectedResponse, responseEntity.getBody());
+        verify(restaurantApplicationService, times(1)).getPublicRestaurants(any(GetPublicRestaurantListQuery.class));
+    }
+
+    @Test
+    void shouldReturnSinglePublicRestaurantSuccessfully() {
+        // Arrange
+        UUID restaurantId = UUID.randomUUID();
+        GetPublicRestaurantQueryResponse expectedResponse = new GetPublicRestaurantQueryResponse(null);
+
+        when(restaurantApplicationService.getPublicRestaurant(eq(restaurantId)))
+                .thenReturn(expectedResponse);
+
+        // Act
+        ResponseEntity<GetPublicRestaurantQueryResponse> responseEntity = 
+                publicRestaurantController.getPublicRestaurant(restaurantId);
+
+        // Assert
+        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+        assertEquals(expectedResponse, responseEntity.getBody());
+        verify(restaurantApplicationService, times(1)).getPublicRestaurant(eq(restaurantId));
+    }
+}

--- a/restaurant-service/restaurant-dataaccess/pom.xml
+++ b/restaurant-service/restaurant-dataaccess/pom.xml
@@ -41,6 +41,11 @@
             <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/restaurant-service/restaurant-dataaccess/src/test/java/com/berkay/restaurant/service/dataaccess/restaurant/repository/RestaurantJpaRepositoryTest.java
+++ b/restaurant-service/restaurant-dataaccess/src/test/java/com/berkay/restaurant/service/dataaccess/restaurant/repository/RestaurantJpaRepositoryTest.java
@@ -1,0 +1,111 @@
+package com.berkay.restaurant.service.dataaccess.restaurant.repository;
+
+import com.berkay.restaurant.service.dataaccess.restaurant.entity.RestaurantEntity;
+import com.berkay.restaurant.service.domain.valueobject.CuisineType;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ContextConfiguration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@DataJpaTest
+@ContextConfiguration(classes = RestaurantJpaRepositoryTest.TestConfig.class)
+public class RestaurantJpaRepositoryTest {
+
+    @SpringBootConfiguration
+    @EnableAutoConfiguration
+    @EntityScan(basePackages = "com.berkay.restaurant.service.dataaccess")
+    @EnableJpaRepositories(basePackages = "com.berkay.restaurant.service.dataaccess")
+    static class TestConfig {
+    }
+
+    @Autowired
+    private RestaurantJpaRepository restaurantJpaRepository;
+
+    @Test
+    void shouldFindPublicRestaurantsWithNullParametersWithoutTypeException() {
+        // Arrange
+        RestaurantEntity entity = RestaurantEntity.builder()
+                .restaurantId(UUID.randomUUID())
+                .restaurantName("Test Restaurant")
+                .isActive(true)
+                .cuisineType(CuisineType.TURKISH)
+                .averageDeliveryTimeInMinutes(30)
+                .deliveryFee(BigDecimal.TEN)
+                .minimumOrderAmount(BigDecimal.valueOf(50))
+                .build();
+                
+        restaurantJpaRepository.save(entity);
+
+        // Act - Testing with null parameters to ensure PostgreSQL type inference (bytea) does not throw exception
+        Page<RestaurantEntity> result = restaurantJpaRepository.findPublicRestaurants(null, null, null, PageRequest.of(0, 10));
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+        assertEquals("Test Restaurant", result.getContent().get(0).getRestaurantName());
+    }
+
+    @Test
+    void shouldFindPublicRestaurantsWithSearchName() {
+        // Arrange
+        RestaurantEntity entity = RestaurantEntity.builder()
+                .restaurantId(UUID.randomUUID())
+                .restaurantName("Kebab House")
+                .isActive(true)
+                .cuisineType(CuisineType.TURKISH)
+                .build();
+                
+        restaurantJpaRepository.save(entity);
+
+        // Act
+        Page<RestaurantEntity> result = restaurantJpaRepository.findPublicRestaurants("kebab", null, null, PageRequest.of(0, 10));
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+        assertEquals("Kebab House", result.getContent().get(0).getRestaurantName());
+    }
+
+    @Test
+    void shouldSortAvailableRestaurantsFirst() {
+        // Arrange
+        RestaurantEntity closedEntity = RestaurantEntity.builder()
+                .restaurantId(UUID.randomUUID())
+                .restaurantName("Closed Restaurant")
+                .isActive(true)
+                .available(false)
+                .build();
+
+        RestaurantEntity openEntity = RestaurantEntity.builder()
+                .restaurantId(UUID.randomUUID())
+                .restaurantName("Open Restaurant")
+                .isActive(true)
+                .available(true)
+                .build();
+
+        restaurantJpaRepository.save(closedEntity);
+        restaurantJpaRepository.save(openEntity);
+
+        // Act
+        Page<RestaurantEntity> result = restaurantJpaRepository.findPublicRestaurants(null, null, null, PageRequest.of(0, 10));
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(2, result.getTotalElements());
+        assertEquals("Open Restaurant", result.getContent().get(0).getRestaurantName());
+        assertEquals("Closed Restaurant", result.getContent().get(1).getRestaurantName());
+    }
+}

--- a/restaurant-service/restaurant-domain/restaurant-application-service/src/test/java/com/berkay/restaurant/service/domain/RestaurantQueryHandlerTest.java
+++ b/restaurant-service/restaurant-domain/restaurant-application-service/src/test/java/com/berkay/restaurant/service/domain/RestaurantQueryHandlerTest.java
@@ -1,0 +1,144 @@
+package com.berkay.restaurant.service.domain;
+
+import com.berkay.domain.valueobject.RestaurantId;
+import com.berkay.restaurant.service.domain.dto.read.GetPublicRestaurantListQuery;
+import com.berkay.restaurant.service.domain.dto.read.GetPublicRestaurantListQueryResponse;
+import com.berkay.restaurant.service.domain.dto.read.GetPublicRestaurantQueryResponse;
+import com.berkay.restaurant.service.domain.dto.read.GetRestaurantListQueryResponse;
+import com.berkay.restaurant.service.domain.dto.read.RestaurantPageResult;
+import com.berkay.restaurant.service.domain.entity.Restaurant;
+import com.berkay.restaurant.service.domain.entity.RestaurantPersonnel;
+import com.berkay.restaurant.service.domain.exception.RestaurantNotFoundException;
+import com.berkay.restaurant.service.domain.mapper.RestaurantDataMapper;
+import com.berkay.restaurant.service.domain.ports.output.repository.RestaurantPersonnelRepository;
+import com.berkay.restaurant.service.domain.ports.output.repository.RestaurantRepository;
+import com.berkay.restaurant.service.domain.valueobject.CuisineType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class RestaurantQueryHandlerTest {
+
+    @Mock
+    private RestaurantRepository restaurantRepository;
+
+    @Mock
+    private RestaurantPersonnelRepository restaurantPersonnelRepository;
+
+    private RestaurantDataMapper restaurantDataMapper;
+
+    private RestaurantQueryHandler restaurantQueryHandler;
+
+    private UUID restaurantId;
+    private UUID userId;
+    private Restaurant restaurant;
+
+    @BeforeEach
+    public void setUp() {
+        restaurantDataMapper = new RestaurantDataMapper();
+        restaurantQueryHandler = new RestaurantQueryHandler(restaurantRepository, restaurantPersonnelRepository, restaurantDataMapper);
+
+        restaurantId = UUID.randomUUID();
+        userId = UUID.randomUUID();
+        
+        restaurant = Restaurant.builder()
+                .restaurantId(new RestaurantId(restaurantId))
+                .restaurantName(new com.berkay.restaurant.service.domain.valueobject.RestaurantName("Test Restaurant"))
+                .active(true)
+                .build();
+    }
+
+    @Test
+    public void testGetRestaurants_Success() {
+        RestaurantPersonnel personnel = RestaurantPersonnel.builder()
+                .restaurantPersonnelId(new com.berkay.restaurant.service.domain.valueobject.RestaurantPersonnelId(UUID.randomUUID()))
+                .restaurantId(new RestaurantId(restaurantId))
+                .userId(userId)
+                .build();
+
+        when(restaurantPersonnelRepository.findByUserId(userId)).thenReturn(List.of(personnel));
+        when(restaurantRepository.findAllByIdIn(List.of(restaurantId))).thenReturn(List.of(restaurant));
+
+        GetRestaurantListQueryResponse response = restaurantQueryHandler.getRestaurants(userId);
+
+        assertNotNull(response);
+        assertEquals(1, response.getRestaurants().size());
+        assertEquals("Test Restaurant", response.getRestaurants().get(0).getName());
+    }
+
+    @Test
+    public void testGetRestaurants_NoPersonnelFound() {
+        when(restaurantPersonnelRepository.findByUserId(userId)).thenReturn(List.of());
+
+        GetRestaurantListQueryResponse response = restaurantQueryHandler.getRestaurants(userId);
+
+        assertNotNull(response);
+        assertTrue(response.getRestaurants().isEmpty());
+    }
+
+    @Test
+    public void testGetPublicRestaurants_Success() {
+        GetPublicRestaurantListQuery query = new GetPublicRestaurantListQuery(null, CuisineType.FAST_FOOD, true, 0, 10);
+        RestaurantPageResult pageResult = new RestaurantPageResult(List.of(restaurant), 0, 10, 1, 1, true);
+
+        when(restaurantRepository.findPublicRestaurants(null, CuisineType.FAST_FOOD, true, 0, 10))
+                .thenReturn(pageResult);
+
+        GetPublicRestaurantListQueryResponse response = restaurantQueryHandler.getPublicRestaurants(query);
+
+        assertNotNull(response);
+        assertEquals(1, response.getItems().size());
+        assertEquals(1, response.getTotalElements());
+        assertTrue(response.isLast());
+    }
+
+    @Test
+    public void testGetPublicRestaurant_Success() {
+        when(restaurantRepository.findRestaurantById(restaurantId)).thenReturn(Optional.of(restaurant));
+
+        GetPublicRestaurantQueryResponse response = restaurantQueryHandler.getPublicRestaurant(restaurantId);
+
+        assertNotNull(response);
+        assertEquals(restaurantId, response.getRestaurant().getRestaurantId());
+        assertEquals("Test Restaurant", response.getRestaurant().getName());
+    }
+
+    @Test
+    public void testGetPublicRestaurant_NotActive() {
+        Restaurant inactiveRestaurant = Restaurant.builder()
+                .restaurantId(new RestaurantId(restaurantId))
+                .restaurantName(new com.berkay.restaurant.service.domain.valueobject.RestaurantName("Inactive Restaurant"))
+                .active(false)
+                .build();
+
+        when(restaurantRepository.findRestaurantById(restaurantId)).thenReturn(Optional.of(inactiveRestaurant));
+
+        RestaurantNotFoundException exception = assertThrows(RestaurantNotFoundException.class, 
+            () -> restaurantQueryHandler.getPublicRestaurant(restaurantId));
+
+        assertTrue(exception.getMessage().contains("Active restaurant not found"));
+    }
+
+    @Test
+    public void testGetPublicRestaurant_NotFound() {
+        when(restaurantRepository.findRestaurantById(restaurantId)).thenReturn(Optional.empty());
+
+        RestaurantNotFoundException exception = assertThrows(RestaurantNotFoundException.class, 
+            () -> restaurantQueryHandler.getPublicRestaurant(restaurantId));
+
+        assertTrue(exception.getMessage().contains("Restaurant not found"));
+    }
+}


### PR DESCRIPTION
Added the H2 database dependency to resolve in-memory database configuration issues during @DataJpaTest. Added unit tests for RestaurantJpaRepository, RestaurantQueryHandler, and PublicRestaurantController to verify business requirements.